### PR TITLE
lazy loading for large dataset (#20)

### DIFF
--- a/imantics/image.py
+++ b/imantics/image.py
@@ -105,11 +105,11 @@ class Image(Semantic):
         
         # Create empty image if not provided
         if image_array is None:
-            self.array = np.zeros((height, width, 3)).astype(np.uint8)
+            self.height, self.width = (height,width)
+
         else:
-            self.array = image_array
         
-        self.height, self.width, _ = self.array.shape
+            self.height, self.width, _ = image_array.shape
         
         self.size = (self.width, self.height)
         self.file_name = os.path.basename(self.path)
@@ -172,7 +172,11 @@ class Image(Semantic):
         :returns: Image array with annotations
         :rtype: numpy.ndarray
         """
-        temp_image = self.array.copy()
+        
+        
+        temp_image = cv2.imread(self.path)
+        if temp_image is None:
+            temp_image = np.zeros((self.height,self.width,3)).astype(np.uint8)
         temp_image.setflags(write=True)
 
         for annotation in self.iter_annotations():

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -9,7 +9,6 @@ class TestImageCreate:
 
         assert image.height == height
         assert image.width == width
-        assert image.array.shape == (height, width, 3)
         assert len(image.annotations) == 0
         assert len(image.categories) == 0
 


### PR DESCRIPTION
* Update image.py

change loading of image for drawing instead of loading it for Dataset. Make the tool much more memory efficient for large dataset

* Update image.py

* Update image.py

* Update image.py

* Update test_image.py

change of the test as the array is not memorized anymore